### PR TITLE
RT5616: Revert: issue reset 1, then reset 0 after updating the init list in probe()

### DIFF
--- a/sound/soc/codecs/rt5616.c
+++ b/sound/soc/codecs/rt5616.c
@@ -1432,8 +1432,7 @@ static int rt5616_i2c_probe(struct i2c_client *i2c,
 		return ret;
 	}
 	// Fucking ensure we reset it before reading...
-	regmap_write(rt5616->regmap, RT5616_RESET, 0);
-
+ 	regmap_write(rt5616->regmap, RT5616_RESET, 1); 
 	regmap_read(rt5616->regmap, RT5616_DEVICE_ID, &val);
 	if (val != 0x6281) {
 		dev_err(&i2c->dev,


### PR DESCRIPTION
Fixes the RT5616 detection issue after a warm boot